### PR TITLE
remove httpd.pid before starting httpd

### DIFF
--- a/pkg/docker/entry.sh
+++ b/pkg/docker/entry.sh
@@ -14,4 +14,6 @@ export PGADMIN_SETUP_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
 
 j2 /templates/pgadmin4.conf.j2 > /etc/httpd/conf.d/pgadmin4.conf
 
+rm /run/httpd/httpd.pid
+
 /usr/sbin/httpd -D FOREGROUND


### PR DESCRIPTION
httpd will not start properly if this file exists.  The docker container will exit if httpd exits, making this file useless.

Without this change it is impossible to start the docker container after stopping it.