### PR TITLE
Prevent accidental refreshes

### DIFF
--- a/web/pgadmin/browser/static/js/browser.js
+++ b/web/pgadmin/browser/static/js/browser.js
@@ -1947,6 +1947,8 @@ define('pgadmin.browser', [
   $(window).on('beforeunload', function() {
     if (pgBrowser.get_preference('browser', 'browser_tree_state_save_interval').value !== -1)
       pgAdmin.Browser.browserTreeState.save_state();
+    
+    return "Are you sure? You will lose any unsaved work!";
   });
 
   return pgAdmin.Browser;

--- a/web/pgadmin/browser/static/js/browser.js
+++ b/web/pgadmin/browser/static/js/browser.js
@@ -1948,7 +1948,7 @@ define('pgadmin.browser', [
     if (pgBrowser.get_preference('browser', 'browser_tree_state_save_interval').value !== -1)
       pgAdmin.Browser.browserTreeState.save_state();
     
-    return "Are you sure? You will lose any unsaved work!";
+    alert("Are you sure? You will lose any unsaved work!");
   });
 
   return pgAdmin.Browser;


### PR DESCRIPTION
Since the F5 key in Pgadmin is used to run querys, sometimes after clicking away from a form or encountering an error, it is possible to trigger the browser refresh instead of re-running the query.