### PR TITLE
Added the possiblity to bind to ipv4-address on startup

### DIFF
--- a/pkg/docker/README
+++ b/pkg/docker/README
@@ -47,6 +47,14 @@ The expected paths are `/certs/server.crt` and `/certs/server.key`.
 
 You need to explicitly map these ports with `-p` option to some port at your machine.
 
+PGADMIN_USE_IPV4
+----------------
+
+Default: unset
+
+If not set, the container will try to bind the daemon to a IPV6 address,
+which would result in an error if no IPV6 network is configured on the host system.
+
 Examples
 ========
 
@@ -69,5 +77,15 @@ docker run -p 443:8443 \
            -e "PGADMIN_SETUP_EMAIL=user@domain.com" \
            -e "PGADMIN_SETUP_PASSWORD=SuperSecret" \
            -e "PGADMIN_ENABLE_TLS=1" \
+           -d pgadmin4
+```
+
+Run a simple container with IPV4-binding enabled:
+
+```console
+docker run -p 80:8080 \
+           -e "PGADMIN_SETUP_EMAIL=user@domain.com" \
+           -e "PGADMIN_SETUP_PASSWORD=SuperSecret" \
+           -e "PGADMIN_USE_IPV4=1" \
            -d pgadmin4
 ```

--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -28,9 +28,9 @@ fi
 # Using --threads to have multi-threaded single-process worker
 
 if [ ! -z ${PGADMIN_USE_IPV4} ]; then
-    BIND_ADDRESS=[::]
-else
     BIND_ADDRESS=0.0.0.0
+else
+    BIND_ADDRESS=[::]
 fi
 
 if [ ! -z ${PGADMIN_ENABLE_TLS} ]; then

--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -27,8 +27,14 @@ fi
 # NOTE: currently pgadmin can run only with 1 worker due to sessions implementation
 # Using --threads to have multi-threaded single-process worker
 
-if [ ! -z ${PGADMIN_ENABLE_TLS} ]; then
-    exec gunicorn --bind [::]:${PGADMIN_LISTEN_PORT:-443} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - --keyfile /certs/server.key --certfile /certs/server.cert run_pgadmin:app
+if [ ! -z ${PGADMIN_USE_IPV4} ]; then
+    BIND_ADDRESS=[::]
 else
-    exec gunicorn --bind [::]:${PGADMIN_LISTEN_PORT:-80} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - run_pgadmin:app
+    BIND_ADDRESS=0.0.0.0
+fi
+
+if [ ! -z ${PGADMIN_ENABLE_TLS} ]; then
+    exec gunicorn --bind ${BIND_ADDRESS}:${PGADMIN_LISTEN_PORT:-443} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - --keyfile /certs/server.key --certfile /certs/server.cert run_pgadmin:app
+else
+    exec gunicorn --bind ${BIND_ADDRESS}:${PGADMIN_LISTEN_PORT:-80} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - run_pgadmin:app
 fi


### PR DESCRIPTION
hello everyone,

unfortunately we had difficulties to bind the container to a host for which no IPV6 is configured. 
For this reason we have made the changes so that gunicorn can also bind to an IPV4 address. 

Many thanks for your work.
Best regards

David