### PR TITLE
The container has been modified to support 2 Kubernetes Pod Security …

### DIFF
--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -93,7 +93,19 @@ COPY ./entrypoint.sh /entrypoint.sh
 RUN python -O -m compileall /pgadmin4
 
 # Finish up
+RUN addgroup -S -g 1000 pgadmin && \
+    adduser -S -u 1000 -G pgadmin pgadmin
+
+RUN mkdir /var/log/pgadmin && \
+    mkdir /var/lib/pgadmin && \
+    chown pgadmin:pgadmin /var/log/pgadmin && \
+    chown pgadmin:pgadmin /var/lib/pgadmin
+
+VOLUME /var/log/pgadmin
 VOLUME /var/lib/pgadmin
-EXPOSE 80 443
+VOLUME /tmp
+EXPOSE 8080 8443
+
+USER 1000
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pkg/docker/README
+++ b/pkg/docker/README
@@ -50,7 +50,7 @@ expected paths are /certs/server.crt and /certs/server.key
 
 *PGADMIN_LISTEN_PORT*
 
-Default: 80 or 443 (if TLS is enabled)
+Default: 8080 or 8443 (if TLS is enabled)
 
 Allows the port that the server listens on to be set to a specific value rather
 than using the default.

--- a/pkg/docker/entrypoint.sh
+++ b/pkg/docker/entrypoint.sh
@@ -32,7 +32,7 @@ TIMEOUT=$(cd /pgadmin4 && python -c 'import config; print(config.SESSION_EXPIRAT
 # Using --threads to have multi-threaded single-process worker
 
 if [ ! -z ${PGADMIN_ENABLE_TLS} ]; then
-    exec gunicorn --timeout ${TIMEOUT} --bind ${PGADMIN_LISTEN_ADDRESS:-[::]}:${PGADMIN_LISTEN_PORT:-443} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - --keyfile /certs/server.key --certfile /certs/server.cert run_pgadmin:app
+    exec gunicorn --timeout ${TIMEOUT} --bind ${PGADMIN_LISTEN_ADDRESS:-[::]}:${PGADMIN_LISTEN_PORT:-8443} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - --keyfile /certs/server.key --certfile /certs/server.cert run_pgadmin:app
 else
-    exec gunicorn --timeout ${TIMEOUT} --bind ${PGADMIN_LISTEN_ADDRESS:-[::]}:${PGADMIN_LISTEN_PORT:-80} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - run_pgadmin:app
+    exec gunicorn --timeout ${TIMEOUT} --bind ${PGADMIN_LISTEN_ADDRESS:-[::]}:${PGADMIN_LISTEN_PORT:-8080} -w 1 --threads ${GUNICORN_THREADS:-25} --access-logfile - run_pgadmin:app
 fi


### PR DESCRIPTION
…Policies :

- ReadOnlyRootFilesystem - Requires that containers must run with a read-only root filesystem (i.e. no writable layer)
- MustRunAsNonRoot - Requires that the pod be submitted with a non-zero runAsUser or have the USER directive defined (using a numeric UID) in the image

see : https://kubernetes.io/docs/concepts/policy/pod-security-policy

Now, the container run as a non root user (user pgadmin (1000)) and must start on a non privileged port >= 1024
Default port are 8080 and 8443 (with TLS)