### PR TITLE
Update Docker README volume path

### DIFF
--- a/pkg/docker/README
+++ b/pkg/docker/README
@@ -121,7 +121,7 @@ Run a TLS secured container using a shared config/storage directory in
         -v "/private/var/lib/pgadmin:/var/lib/pgadmin" \
         -v "/path/to/certificate.cert:/certs/server.cert" \
         -v "/path/to/certificate.key:/certs/server.key" \
-        -v "/tmp/servers.json:/servers.json" \
+        -v "/tmp/servers.json:/pgadmin4/servers.json" \
         -e "PGADMIN_DEFAULT_EMAIL=user@domain.com" \
         -e "PGADMIN_DEFAULT_PASSWORD=SuperSecret" \
         -e "PGADMIN_ENABLE_TLS=True" \


### PR DESCRIPTION
Fixed a typo in the second example of `docker run`. 
> Update the path in the container of volume command, in order to pre-loaded the servers from servers.json.