### PR TITLE
Fixed matching python-config and add PGADMIN_PYTHON_EXE_FILE_NAME

### DIFF
--- a/runtime/pgAdmin4.pro
+++ b/runtime/pgAdmin4.pro
@@ -28,6 +28,7 @@ QMAKE_LFLAGS += $$(PGADMIN_LDFLAGS)
 
 # Figure out where/what Python looks like and that it's suitable
 PYTHON_DIR = $$(PGADMIN_PYTHON_DIR)
+PYTHON_EXE_FILE_NAME = $$(PGADMIN_PYTHON_EXE_FILE_NAME)
 
 equals(PYTHON_DIR, "") {
     error(The PGADMIN_PYTHON_DIR environment variable is not set. Please set it to a directory path under which Python 3.4 or later has been installed and try again.)
@@ -42,11 +43,15 @@ win32 {
     } else {
         message(Platform: Linux)
     }
-    PYTHON_EXE = $${PYTHON_DIR}/bin/python3
+    equals(PYTHON_EXE_FILE_NAME, "") {
+        PYTHON_EXE = $${PYTHON_DIR}/bin/python3
+    } else {
+        PYTHON_EXE = $${PYTHON_DIR}/bin/$${PYTHON_EXE_FILE_NAME}
+    }
 }
 
 !exists($$PYTHON_EXE) {
-    error(The Python executable ($$PYTHON_EXE) could not be found. Please ensure the PGADMIN_PYTHON_DIR environment variable is correctly set.)
+    error(The Python executable ($$PYTHON_EXE) could not be found. Please ensure the PGADMIN_PYTHON_DIR environment variable is correctly set. Or set PGADMIN_PYTHON_EXE_FILE_NAME if the executable filename is different from python3)
 }
 message(Python executable: $$PYTHON_EXE)
 
@@ -69,7 +74,7 @@ win32 {
 }
 else {
     # Find the best matching python-config (there may be more than one)
-    exists($PYTHON_DIR/bin/python$${PYTHON_VERSION}-config) {
+    exists($${PYTHON_DIR}/bin/python$${PYTHON_VERSION}-config) {
         PYTHON_CONFIG = $$PYTHON_DIR/bin/python$${PYTHON_VERSION}-config
     } else: exists($${PYTHON_DIR}/bin/python$${PYTHON_MAJOR_VERSION}-config) {
         PYTHON_CONFIG = $${PYTHON_DIR}/bin/python$${PYTHON_MAJOR_VERSION}-config


### PR DESCRIPTION
I wanted to use python3.8, but there are only files like this in the bin folder:
```
$ ll /opt/python3.8/bin/
total 64
drwxr-xr-x 2 root root  4096 Oct  9 18:59 ./
drwxr-xr-x 6 root root  4096 Jun  4 15:20 ../
-rwxr-xr-x 1 root root   105 Oct  7 02:57 2to3-3.8*
-rwxr-xr-x 1 root root   242 Oct  7 02:57 easy_install*
-rwxr-xr-x 1 root root   242 Oct  7 02:57 easy_install-3.8*
-rwxr-xr-x 1 root root   103 Oct  7 02:57 idle3.8*
-rwxr-xr-x 1 root root   233 Oct  7 02:57 pip*
-rwxr-xr-x 1 root root   233 Oct  7 02:57 pip3*
-rwxr-xr-x 1 root root   233 Oct  7 02:57 pip3.8*
-rwxr-xr-x 1 root root    88 Oct  7 02:57 pydoc3.8*
-rwxr-xr-x 1 root root 10152 Oct  7 02:57 python3.8*
-rwxr-xr-x 1 root root  3217 Oct  7 02:57 python3.8-config*
-rwxr-xr-x 1 root root   250 Oct  7 02:57 virtualenv*
-rwxr-xr-x 1 root root   220 Oct  7 02:57 wheel*
```
I just replaced python3 with python3.8 and expected it to work. But found a bug in the best matching python-config when in python name using major and minor version